### PR TITLE
only register output on completion of ETX,

### DIFF
--- a/abct/output.py
+++ b/abct/output.py
@@ -7,4 +7,4 @@ bin_to_bb2 = lambda s: sum([int(c) * 2 ** i for i,c in enumerate(s.replace(' ', 
 # Output encoded BCT bytes (with STX=\x02, ETX=\x03, start bit = 1, stop bit = 0 checking):
 bct_out = lambda s: b''.join([bytes([(int(s[len(s)%10:][i*10+1:i*10+9], 2)) for i in range(len(s)//10) if s[len(s)%10:][i*10] == '1' and s[len(s)%10:][(i+1)*10-1] == '0'])])[1:-1]
 abct_out = lambda i: bct_out(bct(i))
-has_out = lambda p, d: p // 2**(s(p) - 2) == 5 and d > 2**10 and d // 2**(s(d) - 10) == 2 * 3**6 - 7**2
+has_out = lambda p, d: p // 2**(s(p) - 2) == 5 and d > 2**10 and d // 2**(s(d) - 10) == 2 * 3**6 - 7**2 and not d & 1


### PR DESCRIPTION
Only register output on completion of ETX, not in subsequent steps.

Data is treated as output only on the first step it is completed (i.e. on writing the stopbit `0` of the ETX byte).


Hello, World! and truth machine examples tested and work as expected.

**TODO:**
* [x] Test what happens when  a new output string is added to a data string containing older, already output, strings.



Test program which identified this issue:

```
397444631628981487398138749046400654145762820381874332451597321734669043887712482900704872660133498355324859058465554740779924491293392484209737542410557232609207823832865262188517270401297099211568553174167047953741220829368704232762
```

Which should output 'False' on input value `4`  (bitstring: `10`), 'True' on input value `6` (bitstring: `11`)

**Buggy behaviour:**  'True' was output multiple times after the initial formation of the encoded output string. It was being triggered by the state program string during the 'False' block, even though the leftmost bit of the datastring was set to `0` during these steps.

**Expected:** 'True' is output only once. 


Psuedocode / WIP [CT-BASIC](https://github.com/hornc/CTBASIC) code which was compiled into the above ABCT example:

```
REM Conditional test on input.
INPUT _
INPUT a

ASM 1;10;01;

IF a THEN
  PRINT "True"
  CLEAR 1
ELSE
  PRINT "False"
ENDIF
CLEAR 500
END
```

## Testing:

    ./abct-cli 5260135901548373507240989882880128665550339802823173859498280903068732154297080822113666536277588451226982968856178217713019432250183803863127814770652667583359038425858143801048177086797839560920242143679075670 2 | fgrep OUTPUT | cut -f3

Output:
```
110000001001010011110101101110010110010101000000110 OUTPUT>>> One
11000000100101001111010110111001011001010100000011010000001001010101000101110111010110111101000000110 OUTPUT>>> Two
```

The "One" string is still encoded in the data string, but only the most recently added "Two" string is ouput (once, on completion of the ETX + correct stop bit.