### PR TITLE
Fast output CLI

### DIFF
--- a/abct-cli
+++ b/abct-cli
@@ -3,6 +3,7 @@ import sys
 from abct.abct import pn, dn
 from abct.output import abct_out, bct, has_out
 
+out = 'OUTPUT>>>\t'
 p, d = (int(a) for a in sys.argv[1:3])
 
-while d: print('%s\t%s\t%s%s' % (p, d, bct(d), ' OUTPUT>>> %s' % abct_out(d).decode()[abct_out(d).decode().rfind('\x02')+1:] if has_out(p, d) else '')); p, d = (pn(p), dn(p, d))
+while d: print(f'{p}\t{d}\t{bct(d)}\t{out + abct_out(d).decode()[abct_out(d).decode().rfind(chr(2))+1:] if has_out(p, d) else ""}'); p, d = (pn(p), dn(p, d))

--- a/abct-fast
+++ b/abct-fast
@@ -5,4 +5,4 @@ from abct.output import abct_out, bct, has_out
 
 p, d, *_ = (int(a) for a in sys.argv[1:3] + [2])
 
-while d: print(abct_out(d).decode()[abct_out(d).decode().rfind(chr(2))+1:], end='') if has_out(p, d) else 0; p, d = (pn(p), dn(p, d))
+while d: print(abct_out(d).decode()[abct_out(d).decode().rfind(chr(2))+1:], end='', flush=True) if has_out(p, d) else 0; p, d = (pn(p), dn(p, d))

--- a/abct-fast
+++ b/abct-fast
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import sys
+from abct.abct import pn, dn
+from abct.output import abct_out, bct, has_out
+
+p, d, *_ = (int(a) for a in sys.argv[1:3] + [2])
+
+while d: print(abct_out(d).decode()[abct_out(d).decode().rfind(chr(2))+1:], end='') if has_out(p, d) else 0; p, d = (pn(p), dn(p, d))


### PR DESCRIPTION
Modifies the existing CLI tool to have full TSV output.

Up to 5 columns output:

`program value`, `data value`, `data binary`, `(output flag)`, `(output string)`

The last two columns only appear when there is output in the data string.

Also adds a lighter weight CLI interpreter `abct-fast` which omits all debug / internal state output and only writes program output to STDOUT. To be used when a program is fully debugged and considered "working".

The constant `print()`ing and extra conversions at every step was slowing down the `abct-cli` interpreter unnecessarily for applications which only require the program output. 